### PR TITLE
Add a bunch of trivial implications

### DIFF
--- a/lib/gpd.gd
+++ b/lib/gpd.gd
@@ -195,6 +195,7 @@ DeclareOperation( "IdentityArrow", [ IsGroupoid, IsObject ] );
 #A  ElementsOfGroupoid( <gpd> ) 
 ##
 DeclareProperty( "IsHomsetCosets", IsGroupoidElementCollection );
+InstallTrueMethod(IsListOrCollection, IsHomsetCosets);
 DeclareRepresentation( "IsHomsetCosetsRep", IsHomsetCosets 
     and IsAttributeStoringRep and IsComponentObjectRep, 
     [ "tgroup", "hgroup", "tobj", "hobj", "trays", "hrays", "rep", "type" ] ); 

--- a/lib/gpdaut.gd
+++ b/lib/gpdaut.gd
@@ -20,6 +20,11 @@ DeclareProperty( "IsGroupoidAutomorphismByGroupAuto", IsGroupoidAutomorphism );
 DeclareProperty( "IsGroupoidAutomorphismByObjectPerm", IsGroupoidAutomorphism );
 DeclareProperty( "IsGroupoidAutomorphismByPiecesPerm", IsGroupoidAutomorphism );
 DeclareProperty( "IsGroupoidAutomorphismByRayShifts", IsGroupoidAutomorphism );
+
+InstallTrueMethod(IsGroupoidAutomorphism, IsGroupoidAutomorphismByGroupAuto);
+InstallTrueMethod(IsGroupoidAutomorphism, IsGroupoidAutomorphismByObjectPerm);
+InstallTrueMethod(IsGroupoidAutomorphism, IsGroupoidAutomorphismByPiecesPerm);
+InstallTrueMethod(IsGroupoidAutomorphism, IsGroupoidAutomorphismByRayShifts);
  
 ############################################################################# 
 ## 
@@ -59,10 +64,13 @@ DeclareOperation( "GroupoidInnerAutomorphism",
 #A  EmbeddingsInNiceObject( <gp> ) 
 ##  
 DeclareProperty( "IsAutomorphismGroupOfGroupoid", IsGroup );
-DeclareProperty( "IsGroupOfGroupoidAutomorphisms", IsGroup ); 
+DeclareProperty( "IsGroupOfGroupoidAutomorphisms", IsGroup );
 DeclareAttribute( "AutomorphismGroupOfGroupoid", IsGroupoid ); 
 DeclareOperation( "NiceObjectAutoGroupGroupoid", [ IsGroupoid, IsGroup ] );
 DeclareAttribute( "EmbeddingsInNiceObject", IsGroup ); 
+
+InstallTrueMethod( IsGroup, IsAutomorphismGroupOfGroupoid );
+InstallTrueMethod( IsGroup, IsGroupOfGroupoidAutomorphisms );
 
 ############################################################################# 
 ## 
@@ -85,6 +93,8 @@ DeclareAttribute( "IsomorphismClassPositionsOfGroupoid", IsGroupoid );
 ##  
 DeclareProperty( "IsAutomorphismOfHomogeneousDiscreteGroupoid", 
     IsGroupoidAutomorphism );
+InstallTrueMethod(IsGroupoidAutomorphism, IsAutomorphismOfHomogeneousDiscreteGroupoid);
+
 DeclareOperation( "GroupoidAutomorphismByGroupAutos", 
     [ IsHomogeneousDiscreteGroupoid, IsHomogeneousList ] );
 DeclareOperation( "GroupoidAutomorphismByGroupAutosNC", 

--- a/lib/mwohom.gd
+++ b/lib/mwohom.gd
@@ -71,6 +71,10 @@ DeclareProperty( "IsMonoidWithObjectsHomomorphism",
 DeclareProperty( "IsGroupWithObjectsHomomorphism", 
     IsMagmaWithObjectsHomomorphism );
 
+InstallTrueMethod( IsMagmaWithObjectsHomomorphism, IsSemigroupWithObjectsHomomorphism );
+InstallTrueMethod( IsMagmaWithObjectsHomomorphism, IsMonoidWithObjectsHomomorphism );
+InstallTrueMethod( IsMagmaWithObjectsHomomorphism, IsGroupWithObjectsHomomorphism );
+
 ############################################################################## 
 ## 
 #C  IsGroupoidHomomorphism( <map> )


### PR DESCRIPTION
This makes various "hidden" implications created by `DeclareProperty` explicit, thus fixing a bunch of warnings that show up if one starts the upcoming GAP 4.11 with the `-N` command line option, and then loads this package.

For some information on the background of this, see also <https://github.com/gap-system/gap/issues/1649> and <https://github.com/gap-system/gap/issues/2336>