### PR TITLE
Mark nice monomorphisms explicitly as injective

### DIFF
--- a/lib/gpdaut.gi
+++ b/lib/gpdaut.gi
@@ -647,6 +647,7 @@ function( gpd )
             return q;             
         end); 
 
+    SetIsInjective( nicemap, true );
     SetNiceMonomorphism( aut, nicemap ); 
     ## SetIsHandledByNiceMonomorphism( aut, true ); 
     SetIsCommutative( aut, IsCommutative( niceob[1] ) );
@@ -734,6 +735,7 @@ function( gpd )
             return q;             
         end); 
 
+    SetIsInjective( nicemap, true );
     SetNiceMonomorphism( aut, nicemap ); 
     ## SetIsHandledByNiceMonomorphism( aut, true ); 
     #?  SetInnerAutomorphismsAutomorphismGroup( aut, ?? );  


### PR DESCRIPTION
This avoids potential bugs when code tries to compute kernels of nice monos

For some background:
- https://github.com/gap-system/gap/issues/5020
- https://github.com/gap-system/gap/pull/5029
- https://github.com/gap-system/gap/issues/5037 